### PR TITLE
Amendments

### DIFF
--- a/dans-intellij-inspections.xml
+++ b/dans-intellij-inspections.xml
@@ -1,16 +1,6 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="dans-intellij-inspections" />
-    <inspection_tool class="BashSimpleVarUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreAnonymousInnerClasses" value="false" />
-      <option name="superClassString" value="" />
-    </inspection_tool>
-    <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoreAnonymousInnerClasses" value="false" />
-      <option name="superClassString" value="" />
-    </inspection_tool>
-  </profile>
-</component>
+<profile version="1.0">
+  <option name="myName" value="dans-intellij-inspections" />
+  <inspection_tool class="BashSimpleVarUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
+  <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
+</profile>


### PR DESCRIPTION
* I don't know why version does not have the `InspectionProjectProfileManager` element. This difference is not my point, but unfortunately leads to a less clear diff.
* I removed `SerializableHasSerialVersionUIDField` and `SerializableInnerClassHasSerialVersionUIDField`. The reason is that I think it is not really necessary to have a custom serialVersionUID field in your serializable classes, at least not in the scenarios we deal with. In practice making this mandatory leads to people just adding `1L` all the time or generating one once and never changing it, but *not* to them carefully considering whether they have made a non-backwards-compatible change. So I prefer *any* change leading to a different serialVersionUID (which happens if you don't specify it) over it never changing.